### PR TITLE
I've corrected the `featuredParts` text. It was displaying as 'featur…

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -90,6 +90,7 @@ const resources = {
 
       // Categories
       popularCategories: "Popular Categories",
+      featuredParts: "Featured Parts",
       engineParts: "Engine Parts",
       brakeSystem: "Brake System",
       suspension: "Suspension",
@@ -296,6 +297,7 @@ const resources = {
 
       // Categories
       popularCategories: "Catégories populaires",
+      featuredParts: "Pièces en vedette",
       engineParts: "Pièces moteur",
       brakeSystem: "Système de freinage",
       suspension: "Suspension",
@@ -431,6 +433,7 @@ const resources = {
 
       // Categories
       popularCategories: "Makundi Maarufu",
+      featuredParts: "Vipengee Vilivyoangaziwa",
       engineParts: "Vipengee vya Injini",
       brakeSystem: "Mfumo wa Breki",
       suspension: "Kusimamisha",
@@ -564,6 +567,7 @@ const resources = {
 
       // Categories
       popularCategories: "Nneɛma a Agye Din",
+      featuredParts: "Nneɛma a Wɔayi no Adi",
       engineParts: "Injin Nneɛma",
       brakeSystem: "Breki Nhyehyɛe",
       suspension: "Ntwentwɛn",
@@ -698,6 +702,7 @@ const resources = {
 
       // Categories
       popularCategories: "Awọn Ẹka Olokiki",
+      featuredParts: "Awọn ẹya Ifihan",
       engineParts: "Awọn Ẹya Enjini",
       brakeSystem: "Eto Breki",
       suspension: "Duduro",


### PR DESCRIPTION
…edParts' instead of 'Featured Parts' because the `featuredParts` key was missing from the translation files. I've now added this key to all language translation objects.