### PR TITLE
fix: Correct dashboard link for logged-out users

### DIFF
--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -101,7 +101,7 @@ const MobileHeader = () => {
             <Button
               variant="ghost"
               className="text-white font-semibold"
-              onClick={() => window.location.href = '/buyer-auth'}
+              onClick={() => window.location.href = '/auth'}
             >
               {t('dashboard')}
             </Button>


### PR DESCRIPTION
Redirect non-logged-in users to the generic authentication page (`/auth`) instead of the buyer-specific authentication page (`/buyer-auth`) when you click the 'Dashboard' button in the header.