### PR TITLE
Fix(routing): Correct seller dashboard redirection

### DIFF
--- a/src/components/DashboardRouter.test.tsx
+++ b/src/components/DashboardRouter.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useNavigate }d from 'react-router-dom';
+import { AuthContext } from '@/contexts/AuthContext';
+import DashboardRouter from './DashboardRouter';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+describe('DashboardRouter', () => {
+  it('should redirect a seller to the seller dashboard', () => {
+    const navigate = jest.fn();
+    (useNavigate as jest.Mock).mockReturnValue(navigate);
+
+    const authContextValue = {
+      user: { id: '123', user_metadata: { user_type: 'supplier' } },
+      loading: false,
+      profileLoading: false,
+      userType: 'supplier',
+    };
+
+    render(
+      <AuthContext.Provider value={authContextValue}>
+        <DashboardRouter />
+      </AuthContext.Provider>
+    );
+
+    expect(navigate).toHaveBeenCalledWith('/seller-dashboard');
+  });
+});

--- a/src/components/DashboardRouter.tsx
+++ b/src/components/DashboardRouter.tsx
@@ -4,97 +4,58 @@ import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/integrations/supabase/client";
 
 const DashboardRouter = () => {
-  const { user, loading: authLoading } = useAuth();
+  const {
+    user,
+    loading: authLoading,
+    profileLoading,
+    userType,
+  } = useAuth();
   const navigate = useNavigate();
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Wait until auth state is determined
-    if (authLoading) {
-      console.log("DashboardRouter: Auth state is loading, waiting...");
+    // Wait until auth and profile loading are finished
+    if (authLoading || profileLoading) {
+      console.log(
+        "DashboardRouter: Waiting for auth and profile to load...",
+        { authLoading, profileLoading }
+      );
       return;
     }
 
-    const redirectToUserDashboard = async () => {
-      if (!user) {
-        console.log("DashboardRouter: No user found, redirecting to auth");
-        navigate("/auth");
-        return;
-      }
+    // If no user, redirect to auth page
+    if (!user) {
+      console.log("DashboardRouter: No user found, redirecting to auth");
+      navigate("/auth");
+      return;
+    }
 
-      try {
-        console.log("DashboardRouter: Checking user type for:", user.id);
+    // Determine final user type, falling back to metadata if necessary
+    const finalUserType = userType || user.user_metadata?.user_type || "owner";
+    console.log("DashboardRouter: Final user type for redirection:", finalUserType);
 
-        // Retry mechanism to fetch profile
-        let profile = null;
-        let error = null;
-        for (let i = 0; i < 3; i++) {
-          const { data, error: queryError } = await supabase
-            .from("profiles")
-            .select("user_type")
-            .eq("id", user.id)
-            .single();
+    // Redirect based on the final user type
+    switch (finalUserType) {
+      case "supplier":
+        console.log(
+          "DashboardRouter: Redirecting supplier to seller dashboard"
+        );
+        navigate("/seller-dashboard");
+        break;
+      case "admin":
+        console.log("DashboardRouter: Redirecting admin to admin dashboard");
+        navigate("/admin");
+        break;
+      default:
+        console.log(
+          "DashboardRouter: Redirecting to buyer dashboard for user_type:",
+          finalUserType
+        );
+        navigate("/buyer-dashboard");
+        break;
+    }
+  }, [user, navigate, authLoading, profileLoading, userType]);
 
-          if (data) {
-            profile = data;
-            error = null;
-            break;
-          }
-
-          error = queryError;
-          if (queryError && queryError.code !== 'PGRST116') {
-            break; // Don't retry on critical errors
-          }
-
-          console.log(`DashboardRouter: Profile not found, attempt ${i + 1}. Retrying...`);
-          await new Promise(res => setTimeout(res, 1000)); // Wait 1 second
-        }
-
-        console.log("DashboardRouter: Profile query result:", { profile, error });
-
-        if (error && error.code !== 'PGRST116') {
-          console.error("DashboardRouter: Error fetching profile:", error);
-          navigate("/buyer-dashboard"); // Default to buyer dashboard on error
-          return;
-        }
-
-        let userType = profile?.user_type;
-
-        // If profile still doesn't exist, check user metadata as a fallback
-        if (!userType) {
-          userType = user.user_metadata?.user_type || "owner";
-          console.log("DashboardRouter: Using metadata user_type:", userType);
-        }
-
-        console.log("DashboardRouter: Final user type:", userType);
-
-        // Redirect based on user type
-        switch (userType) {
-          case "supplier":
-            console.log("DashboardRouter: Redirecting supplier to seller dashboard");
-            navigate("/seller-dashboard");
-            break;
-          case "admin":
-            console.log("DashboardRouter: Redirecting admin to admin dashboard");
-            navigate("/admin");
-            break;
-          default:
-            console.log("DashboardRouter: Redirecting to buyer dashboard for user_type:", userType);
-            navigate("/buyer-dashboard");
-            break;
-        }
-      } catch (error) {
-        console.error("DashboardRouter: Error handling dashboard redirect:", error);
-        navigate("/buyer-dashboard"); // Default to buyer dashboard on error
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    redirectToUserDashboard();
-  }, [user, navigate, authLoading]);
-
-  if (loading || authLoading) {
+  if (authLoading || profileLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,6 +11,7 @@ interface AuthContextType {
   user: User | null;
   session: Session | null;
   loading: boolean;
+  profileLoading: boolean; // New state for profile loading
   isPasswordReset: boolean;
   userType: string | null;
   firstName: string | null;
@@ -43,11 +44,13 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
+  const [profileLoading, setProfileLoading] = useState(true);
   const [isPasswordReset, setIsPasswordReset] = useState(false);
   const [userType, setUserType] = useState<string | null>(null);
   const [firstName, setFirstName] = useState<string | null>(null);
 
   const fetchUserProfile = async (userId: string) => {
+    setProfileLoading(true);
     try {
       const { data: profile, error } = await supabase
         .from("profiles")
@@ -66,6 +69,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }
     } catch (error) {
       console.error("Error fetching user profile:", error);
+    } finally {
+      setProfileLoading(false);
     }
   };
 
@@ -711,6 +716,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     user,
     session,
     loading,
+    profileLoading,
     isPasswordReset,
     userType,
     firstName,


### PR DESCRIPTION
This commit fixes a race condition in the `DashboardRouter` that caused sellers to be incorrectly redirected to the buyer's dashboard.

The issue was that the `DashboardRouter` would sometimes attempt to redirect you before your profile, including your `user_type`, had been loaded. This would cause the router to fall back to the default redirection, which was the buyer's dashboard.

To fix this, a new `profileLoading` state has been added to the `AuthContext`. The `DashboardRouter` now waits for both the authentication and the profile to be loaded before redirecting you, ensuring that the correct `user_type` is available.