### PR TITLE
fix: Correct admin dashboard navigation

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -77,11 +77,15 @@ const AdminDashboard = () => {
   };
 
   const handleGoBack = () => {
-    navigate(-1);
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate('/admin');
+    }
   };
 
   const handleGoHome = () => {
-    navigate('/admin-dashboard');
+    navigate('/admin');
   };
 
   // Auto-refresh disabled to prevent UI instability - data will refresh on user actions


### PR DESCRIPTION
The home button on the admin dashboard was navigating to `/admin-dashboard`, but the correct route is `/admin`. This change corrects the navigation to use the proper route.

The back button was also updated to navigate to `/admin` as a fallback if there is no page in your browser's history to go back to.