### PR TITLE
feat: handle 'new_part_request' notification type

### DIFF
--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -40,6 +40,9 @@ const NotificationDropdown = () => {
       case 'new_review':
         navigate('/seller-dashboard?tab=reviews');
         break;
+      case 'new_part_request':
+        navigate('/requested-car-parts');
+        break;
       default:
         navigate('/dashboard');
         break;


### PR DESCRIPTION
This commit adds a new case to the notification dropdown to handle the 'new_part_request' notification type. When a notification of this type is clicked, you are redirected to the '/requested-car-parts' page.