### PR TITLE
fix: Correct dashboard routing for all user types

### DIFF
--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -21,7 +21,12 @@ const MobileHeader = () => {
   const location = useLocation();
   const isHomePage = location.pathname === '/';
 
-  const dashboardUrl = userType === 'seller' ? '/seller-dashboard' : '/buyer-dashboard';
+  const dashboardUrl =
+    userType === 'admin'
+      ? '/admin-dashboard'
+      : userType === 'seller' || userType === 'supplier'
+      ? '/seller-dashboard'
+      : '/buyer-dashboard';
 
   const handleSignOut = async () => {
     try {


### PR DESCRIPTION
Previously, the dashboard button in the mobile header only checked for the 'seller' user type, defaulting all other user types to the buyer dashboard. This change updates the logic to correctly route 'admin', 'seller', and 'supplier' user types to their respective dashboards.