### PR TITLE
feat: Reduce featured parts card size

### DIFF
--- a/src/components/CarPartCard.tsx
+++ b/src/components/CarPartCard.tsx
@@ -53,48 +53,19 @@ const CarPartCard = ({ part, onContact }: CarPartCardProps) => {
           onExpand={handleCardClick}
         />
 
-        <Collapsible open={isCollapsibleOpen} onOpenChange={setIsCollapsibleOpen}>
-          {/* Always visible basic info */}
-          <div className="cursor-pointer" onClick={handleCardClick}>
-            <CarPartCardContent
-              part={part}
-              onExpand={handleCardClick}
-            />
-          </div>
-
-          {/* Collapsible trigger */}
-          <div className="px-4 pb-2">
-            <CollapsibleTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-center gap-2 text-muted-foreground hover:text-foreground"
-                onClick={handleToggleCollapsible}
-              >
-                {isCollapsibleOpen ? (
-                  <>
-                    <ChevronUp className="h-4 w-4" />
-                    Show Less
-                  </>
-                ) : (
-                  <>
-                    <ChevronDown className="h-4 w-4" />
-                    Show More
-                  </>
-                )}
-              </Button>
-            </CollapsibleTrigger>
-          </div>
-
-          {/* Collapsible footer with action buttons */}
-          <CollapsibleContent>
-            <CarPartCardFooter
-              partId={part.id}
-              supplierId={part.supplier_id}
-              onContact={handleContactClick}
-            />
-          </CollapsibleContent>
-        </Collapsible>
+        <div onClick={handleCardClick} className="cursor-pointer">
+          <CarPartCardContent
+            part={part}
+            onExpand={handleCardClick}
+          />
+        </div>
+        <div className="px-3 pb-3">
+          <CarPartCardFooter
+            partId={part.id}
+            supplierId={part.supplier_id}
+            onContact={handleContactClick}
+          />
+        </div>
       </Card>
 
       <CarPartExpandedDialog

--- a/src/components/CarPartCardContent.tsx
+++ b/src/components/CarPartCardContent.tsx
@@ -53,66 +53,62 @@ const CarPartCardContent = ({ part, onExpand }: CarPartCardContentProps) => {
   console.log('CarPartCardContent - profiles data:', part.profiles);
 
   return (
-    <div onClick={onExpand}>
-      <CardHeader className="pb-3 sm:pb-4">
-        <div className="space-y-2 sm:space-y-3">
-          <h3 className="text-lg sm:text-xl lg:text-2xl font-bold text-foreground line-clamp-2 leading-tight">
-            {part.title}
-          </h3>
-          <div className="flex items-center justify-between">
-            <p className="text-sm sm:text-base text-muted-foreground">
-              {part.make} {part.model} ({part.year})
+    <div onClick={onExpand} className="p-3">
+      <div className="space-y-2">
+        <h3 className="text-base font-bold text-foreground line-clamp-2 leading-tight">
+          {part.title}
+        </h3>
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            {part.make} {part.model} ({part.year})
+          </p>
+          <div className="text-right">
+            <p className="text-base font-bold text-green-600">
+              {part.currency} {part.price}
             </p>
-            <div className="text-right">
-              <p className="text-xl sm:text-2xl lg:text-3xl font-bold text-green-600">
-                {part.currency} {part.price}
-              </p>
-            </div>
           </div>
         </div>
-      </CardHeader>
+      </div>
 
-      <CardContent className="py-3 sm:py-4">
-        <div className="space-y-3 sm:space-y-4">
-          {part.description && (
-            <p className="text-sm sm:text-base text-muted-foreground line-clamp-2">
-              {part.description}
-            </p>
-          )}
-          
-          <div className="space-y-2 sm:space-y-3">
-            <div className="flex items-center gap-2 text-sm sm:text-base text-foreground">
-              <Avatar className="h-7 w-7 sm:h-8 sm:w-8">
-                <AvatarImage src={part.profiles?.profile_photo_url} alt={sellerName} />
-                <AvatarFallback className="text-xs sm:text-sm font-medium">
-                  {initials}
-                </AvatarFallback>
-              </Avatar>
-              <span className="font-medium">{sellerName}</span>
-              <VerifiedSellerBadge isVerified={part.profiles?.is_verified || false} size="sm" />
-            </div>
-            
-            <SellerRatingDisplay
-              rating={part.profiles?.rating || 0}
-              totalRatings={part.profiles?.total_ratings || 0}
-              size="sm"
-              showBadge={true}
-            />
-          </div>
+      <div className="mt-2 space-y-2">
+        {part.description && (
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {part.description}
+          </p>
+        )}
 
-          <div className="flex items-center gap-2 text-sm sm:text-base text-muted-foreground">
-            <MapPin className="h-4 w-4" />
-            <span className={`truncate ${inSameCity ? 'text-green-600 font-medium' : ''}`}>
-              {locationDisplayText}
-            </span>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-xs text-foreground">
+            <Avatar className="h-6 w-6">
+              <AvatarImage src={part.profiles?.profile_photo_url} alt={sellerName} />
+              <AvatarFallback className="text-xs font-medium">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+            <span className="font-medium truncate">{sellerName}</span>
+            <VerifiedSellerBadge isVerified={part.profiles?.is_verified || false} size="xs" />
           </div>
           
-          <div className="flex items-center gap-2 text-sm sm:text-base text-muted-foreground">
-            <Calendar className="h-4 w-4" />
-            <span>Listed {formatDate(part.created_at)}</span>
-          </div>
+          <SellerRatingDisplay
+            rating={part.profiles?.rating || 0}
+            totalRatings={part.profiles?.total_ratings || 0}
+            size="xs"
+            showBadge={true}
+          />
         </div>
-      </CardContent>
+
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <MapPin className="h-3 w-3" />
+          <span className={`truncate ${inSameCity ? 'text-green-600 font-medium' : ''}`}>
+            {locationDisplayText}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Calendar className="h-3 w-3" />
+          <span>Listed {formatDate(part.created_at)}</span>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/CarPartCardImage.tsx
+++ b/src/components/CarPartCardImage.tsx
@@ -22,7 +22,7 @@ const CarPartCardImage = ({ partId, title, condition, images, isFeatured, onExpa
   return (
     <div className="relative cursor-pointer" onClick={onExpand}>
       {imageUrl ? (
-        <div className="relative h-48 bg-gray-100">
+        <div className="relative h-32 bg-gray-100">
           <img
             src={imageUrl}
             alt={title}

--- a/src/components/MobileHomeContent.tsx
+++ b/src/components/MobileHomeContent.tsx
@@ -129,7 +129,7 @@ const MobileHomeContent = () => {
         
         {featuredLoading ? (
           <div className="grid grid-cols-2 gap-3">
-            {[1, 2].map((i) => (
+            {[1, 2, 3, 4, 5, 6].map((i) => (
               <Card key={i} className="animate-pulse">
               <CardContent className="p-4">
                 <div className="bg-gray-200 dark:bg-gray-700 h-32 rounded-lg mb-3"></div>
@@ -142,7 +142,7 @@ const MobileHomeContent = () => {
           </div>
         ) : featuredParts.length > 0 ? (
           <div className="grid grid-cols-2 gap-3">
-            {featuredParts.slice(0, 2).map((part) => (
+            {featuredParts.slice(0, 6).map((part) => (
               <CarPartCard key={part.id} part={part} />
             ))}
           </div>


### PR DESCRIPTION
This commit reduces the size of the featured parts cards to allow for more cards to be displayed on the home page.

Changes include:
- Displaying up to 6 featured parts instead of 2.
- Reducing the height of the card image.
- Making the card content more compact by reducing padding and font sizes.
- Simplifying the card by removing the collapsible section.