### PR TITLE
feat: Make featured parts section responsive

### DIFF
--- a/src/components/CarPartCardContent.tsx
+++ b/src/components/CarPartCardContent.tsx
@@ -53,33 +53,33 @@ const CarPartCardContent = ({ part, onExpand }: CarPartCardContentProps) => {
   console.log('CarPartCardContent - profiles data:', part.profiles);
 
   return (
-    <div onClick={onExpand} className="p-3">
-      <div className="space-y-2">
-        <h3 className="text-base font-bold text-foreground line-clamp-2 leading-tight">
+    <div onClick={onExpand} className="p-2 sm:p-3">
+      <div className="space-y-1 sm:space-y-2">
+        <h3 className="text-sm sm:text-base font-bold text-foreground line-clamp-2 leading-tight">
           {part.title}
         </h3>
         <div className="flex items-center justify-between">
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs sm:text-sm text-muted-foreground">
             {part.make} {part.model} ({part.year})
           </p>
           <div className="text-right">
-            <p className="text-base font-bold text-green-600">
+            <p className="text-sm sm:text-base font-bold text-green-600">
               {part.currency} {part.price}
             </p>
           </div>
         </div>
       </div>
 
-      <div className="mt-2 space-y-2">
+      <div className="mt-2 space-y-1 sm:space-y-2">
         {part.description && (
           <p className="text-xs text-muted-foreground line-clamp-2">
             {part.description}
           </p>
         )}
 
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 text-xs text-foreground">
-            <Avatar className="h-6 w-6">
+        <div className="space-y-1 sm:space-y-2">
+          <div className="flex items-center gap-1 sm:gap-2 text-xs text-foreground">
+            <Avatar className="h-5 w-5 sm:h-6 sm:w-6">
               <AvatarImage src={part.profiles?.profile_photo_url} alt={sellerName} />
               <AvatarFallback className="text-xs font-medium">
                 {initials}
@@ -97,14 +97,14 @@ const CarPartCardContent = ({ part, onExpand }: CarPartCardContentProps) => {
           />
         </div>
 
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1 sm:gap-2 text-xs text-muted-foreground">
           <MapPin className="h-3 w-3" />
           <span className={`truncate ${inSameCity ? 'text-green-600 font-medium' : ''}`}>
             {locationDisplayText}
           </span>
         </div>
 
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1 sm:gap-2 text-xs text-muted-foreground">
           <Calendar className="h-3 w-3" />
           <span>Listed {formatDate(part.created_at)}</span>
         </div>

--- a/src/components/CarPartCardImage.tsx
+++ b/src/components/CarPartCardImage.tsx
@@ -22,7 +22,7 @@ const CarPartCardImage = ({ partId, title, condition, images, isFeatured, onExpa
   return (
     <div className="relative cursor-pointer" onClick={onExpand}>
       {imageUrl ? (
-        <div className="relative h-32 bg-gray-100">
+        <div className="relative h-24 sm:h-32 bg-gray-100">
           <img
             src={imageUrl}
             alt={title}

--- a/src/components/MobileHomeContent.tsx
+++ b/src/components/MobileHomeContent.tsx
@@ -128,8 +128,8 @@ const MobileHomeContent = () => {
         </div>
         
         {featuredLoading ? (
-          <div className="grid grid-cols-2 gap-3">
-            {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+            {[...Array(12)].map((_, i) => (
               <Card key={i} className="animate-pulse">
               <CardContent className="p-4">
                 <div className="bg-gray-200 dark:bg-gray-700 h-32 rounded-lg mb-3"></div>
@@ -141,8 +141,8 @@ const MobileHomeContent = () => {
             ))}
           </div>
         ) : featuredParts.length > 0 ? (
-          <div className="grid grid-cols-2 gap-3">
-            {featuredParts.slice(0, 6).map((part) => (
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+            {featuredParts.slice(0, 12).map((part) => (
               <CarPartCard key={part.id} part={part} />
             ))}
           </div>


### PR DESCRIPTION
This commit makes the featured parts section responsive to different screen sizes.

Changes include:
- Adjusting the grid layout to display more columns on larger screens.
- Making the card content (padding, font sizes) responsive.
- Making the card image height responsive.