### PR TITLE
fix: Handle missing relations in saved parts

### DIFF
--- a/src/hooks/useSavedParts.ts
+++ b/src/hooks/useSavedParts.ts
@@ -50,7 +50,7 @@ export const useSavedParts = () => {
           created_at,
           notes,
           list_name,
-          car_parts!inner(
+          car_parts(
             id,
             title,
             make,


### PR DESCRIPTION
I changed the inner join to a left join when fetching saved parts. This prevents an error when a saved part's related car part or supplier profile is missing.