### PR TITLE
Fix: Prevent infinite loop in useFeaturedParts hook

### DIFF
--- a/src/hooks/useFeaturedParts.ts
+++ b/src/hooks/useFeaturedParts.ts
@@ -9,7 +9,7 @@ export const useFeaturedParts = () => {
 
   useEffect(() => {
     fetchFeaturedParts();
-  }, [featuredParts]);
+  }, []);
 
   const fetchFeaturedParts = async () => {
     try {


### PR DESCRIPTION
The `useEffect` hook in `useFeaturedParts.ts` had `featuredParts` in its dependency array. This caused an infinite loop of re-fetching and re-rendering, which resulted in a flickering effect in the UI.

This commit removes `featuredParts` from the dependency array to ensure that the featured parts are only fetched once when the component mounts.