### PR TITLE
feat: make chat with seller button responsive

### DIFF
--- a/src/components/CarPartCardWithChat.tsx
+++ b/src/components/CarPartCardWithChat.tsx
@@ -303,7 +303,9 @@ const CarPartCardWithChat = ({ part }: CarPartCardWithChatProps) => {
                     size={isMobile ? "mobile-default" : "sm"}
                     variant="outline"
                     className="flex-1 justify-center font-medium"
-                  />
+                  >
+                    Chat <span className="hidden xs:inline">with Seller</span>
+                  </ChatButton>
                   <SaveButton 
                     partId={part.id} 
                     size={isMobile ? "mobile-default" : "sm"}
@@ -453,7 +455,9 @@ const CarPartCardWithChat = ({ part }: CarPartCardWithChatProps) => {
                 partId={part.id}
                 size={isMobile ? "mobile-default" : "default"}
                 className="flex-1 bg-gradient-to-r from-blue-600 to-purple-700 hover:from-blue-700 hover:to-purple-800 justify-center"
-              />
+              >
+                Chat <span className="hidden xs:inline">with Seller</span>
+              </ChatButton>
               <SaveButton 
                 partId={part.id} 
                 size={isMobile ? "mobile-default" : "default"}


### PR DESCRIPTION
The "Chat with Seller" button on the featured parts card now hides the "with Seller" text on extra-small screens to prevent text from overlapping the button.