### PR TITLE
fix: Seller dashboard not displaying all parts

### DIFF
--- a/src/components/MyPartsTab.tsx
+++ b/src/components/MyPartsTab.tsx
@@ -8,12 +8,13 @@ import EditPartModal from "./parts/EditPartModal";
 import InventorySearchControls from "./InventorySearchControls";
 
 interface MyPartsTabProps {
+  parts: CarPart[];
   onRefresh: () => void;
 }
 
-const MyPartsTab = ({ onRefresh }: MyPartsTabProps) => {
+const MyPartsTab = ({ parts, onRefresh }: MyPartsTabProps) => {
   const { hasBusinessSubscription } = useSubscriptionStatus();
-  const { parts, loading, updatePartStatus, deletePart, updatePart, fetchMyParts } = usePartManagement();
+  const { loading, updatePartStatus, deletePart, updatePart, fetchMyParts } = usePartManagement();
   const [selectedPartForBoost, setSelectedPartForBoost] = useState<string | null>(null);
   const [editingPart, setEditingPart] = useState<CarPart | null>(null);
   
@@ -144,7 +145,7 @@ const MyPartsTab = ({ onRefresh }: MyPartsTabProps) => {
               onDelete={deletePart}
               onUpdateStatus={updatePartStatus}
               onToggleBoost={setSelectedPartForBoost}
-              onFeatureUpdate={fetchMyParts}
+              onFeatureUpdate={onRefresh}
             />
           ))}
         </div>

--- a/src/components/SellerTabs.tsx
+++ b/src/components/SellerTabs.tsx
@@ -10,8 +10,7 @@ import RequestsTab from "./RequestsTab";
 import SellerProfileManagement from "./SellerProfileManagement";
 import SubscriptionManager from "./SubscriptionManager";
 import { useSubscriptionStatus } from "@/hooks/useSubscriptionStatus";
-import { useMyPartsCount } from "@/hooks/useMyPartsCount";
-import { usePartManagement } from "@/hooks/usePartManagement";
+import { CarPart } from "@/types/CarPart";
 import TabCountBadge from "./TabCountBadge";
 interface Request {
   id: string;
@@ -49,6 +48,7 @@ interface SupplierTabsProps {
   onTabChange: (tab: string) => void;
   requests: Request[];
   offers: Offer[];
+  myParts: CarPart[];
   onOfferSubmit: (requestId: string, price: number, message: string, location: string) => Promise<void>;
   onWhatsAppContact: (phone: string, request: Request | Offer['request']) => void;
   onChatContact: (requestId: string, ownerId: string) => void;
@@ -59,6 +59,7 @@ const SupplierTabs = ({
   onTabChange,
   requests,
   offers,
+  myParts,
   onOfferSubmit,
   onWhatsAppContact,
   onChatContact,
@@ -68,11 +69,9 @@ const SupplierTabs = ({
   const {
     hasBusinessSubscription
   } = useSubscriptionStatus();
-  const { fetchMyParts } = usePartManagement();
-  const partsCount = useMyPartsCount();
+
   const handlePartPosted = () => {
     setShowPostForm(false);
-    fetchMyParts();
     // You might want to call a refresh function here if available
   };
   const handleViewRequests = () => {
@@ -103,7 +102,7 @@ const SupplierTabs = ({
           <TabsTrigger value="my-parts" className="flex flex-col items-center justify-center gap-1 text-xs px-1 py-2 h-auto data-[state=active]:bg-background data-[state=active]:text-foreground">
             <Package className="h-3 w-3 sm:h-4 sm:w-4" />
             <span className="text-[9px] sm:text-[10px] leading-tight">My Parts</span>
-            <TabCountBadge count={partsCount} />
+            <TabCountBadge count={myParts.length} />
           </TabsTrigger>
           <TabsTrigger value="offers" className="flex flex-col items-center justify-center gap-1 text-xs px-1 py-2 h-auto data-[state=active]:bg-background data-[state=active]:text-foreground">
             <Star className="h-3 w-3 sm:h-4 sm:w-4" />
@@ -130,7 +129,7 @@ const SupplierTabs = ({
             <h3 className="font-semibold text-blue-900 dark:text-blue-100 mb-1 text-sm sm:text-base">My Parts</h3>
             <p className="text-xs sm:text-sm text-blue-700 dark:text-blue-300">All the car parts you have listed for sale as a supplier. Use this to manage, edit, or remove your own listings (your inventory).</p>
           </div>
-          <MyPartsTab onRefresh={fetchMyParts} />
+          <MyPartsTab parts={myParts} onRefresh={() => {}} />
         </TabsContent>
 
         <TabsContent value="offers" className="space-y-3 sm:space-y-4">

--- a/src/hooks/useMyParts.ts
+++ b/src/hooks/useMyParts.ts
@@ -1,0 +1,110 @@
+import { useState, useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { CarPart } from "@/types/CarPart";
+import { useAuth } from "@/contexts/AuthContext";
+
+export const useMyParts = () => {
+  const { user } = useAuth();
+  const [parts, setParts] = useState<CarPart[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchParts = async () => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const { data, error } = await supabase
+        .from("car_parts")
+        .select(
+          `
+          id,
+          supplier_id,
+          title,
+          description,
+          make,
+          model,
+          year,
+          part_type,
+          condition,
+          price,
+          currency,
+          images,
+          latitude,
+          longitude,
+          address,
+          created_at,
+          updated_at,
+          status,
+          is_featured,
+          profiles!inner(
+            first_name,
+            last_name,
+            phone,
+            location,
+            profile_photo_url,
+            is_verified,
+            rating,
+            total_ratings
+          )
+        `
+        )
+        .eq("supplier_id", user.id)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        console.error("Error fetching parts:", error);
+        setError(error.message);
+        return;
+      }
+
+      const transformedParts: CarPart[] = (data || []).map((part) => {
+        let processedImages: string[] = [];
+        if (part.images && Array.isArray(part.images)) {
+          processedImages = part.images
+            .filter((img) => typeof img === "string" && img.trim() !== "")
+            .map((img) => {
+              if (img.startsWith("http")) {
+                return img;
+              }
+              if (img.includes("/")) {
+                const {
+                  data: { publicUrl },
+                } = supabase.storage
+                  .from("car-part-images")
+                  .getPublicUrl(img);
+                return publicUrl;
+              }
+              return img;
+            });
+        }
+
+        return {
+          ...part,
+          condition: part.condition as "New" | "Used" | "Refurbished",
+          status: part.status as "available" | "sold" | "hidden" | "pending",
+          profiles: part.profiles,
+          images: processedImages.length > 0 ? processedImages : undefined,
+        };
+      });
+
+      setParts(transformedParts);
+    } catch (err) {
+      console.error("Unexpected error:", err);
+      setError("An unexpected error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchParts();
+  }, [user]);
+
+  return { parts, loading, error, refetch: fetchParts };
+};

--- a/src/hooks/useMyPartsData.ts
+++ b/src/hooks/useMyPartsData.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect, useRef } from "react";
+import { toast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import { CarPart } from "@/types/CarPart";
+import { useMyParts } from "./useMyParts";
+
+export const useMyPartsData = () => {
+  const { user } = useAuth();
+  const { parts, loading, error, refetch } = useMyParts();
+  const [myParts, setMyParts] = useState<CarPart[]>(parts);
+
+  useEffect(() => {
+    setMyParts(parts);
+  }, [parts]);
+
+  return {
+    myParts,
+    loading,
+    error,
+    refetch,
+  };
+};

--- a/src/hooks/usePartManagement.ts
+++ b/src/hooks/usePartManagement.ts
@@ -1,48 +1,16 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
-import { useAuth } from "@/contexts/AuthContext";
+import { useMyParts } from "./useMyParts";
 import { CarPart } from "@/types/CarPart";
 
 export const usePartManagement = () => {
-  const { user } = useAuth();
-  const [parts, setParts] = useState<CarPart[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { parts: initialParts, loading, refetch: fetchMyParts } = useMyParts();
+  const [parts, setParts] = useState<CarPart[]>(initialParts);
 
-  useEffect(() => {
-    fetchMyParts();
-  }, [user]);
-
-  const fetchMyParts = async () => {
-    if (!user) return;
-
-    try {
-      const { data, error } = await supabase
-        .from('car_parts')
-        .select('*')
-        .eq('supplier_id', user.id)
-        .order('created_at', { ascending: false });
-
-      if (error) throw error;
-      
-      const typedParts = (data || []).map(part => ({
-        ...part,
-        condition: part.condition as 'New' | 'Used' | 'Refurbished',
-        status: part.status as 'available' | 'sold' | 'hidden' | 'pending'
-      }));
-      
-      setParts(typedParts);
-    } catch (error) {
-      console.error('Error fetching parts:', error);
-      toast({
-        title: "Error",
-        description: "Failed to load your parts. Please try again.",
-        variant: "destructive"
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
+  useState(() => {
+    setParts(initialParts);
+  });
 
   const updatePartStatus = async (partId: string, newStatus: string) => {
     try {

--- a/src/pages/SellerDashboard.tsx
+++ b/src/pages/SellerDashboard.tsx
@@ -9,6 +9,7 @@ import SellerStats from "@/components/SellerStats";
 import SellerTabs from "@/components/SellerTabs";
 import SellerWelcomeDashboard from "@/components/SellerWelcomeDashboard";
 import { useSellerData } from "@/hooks/useSellerData";
+import { useMyPartsData } from "@/hooks/useMyPartsData";
 import { useOfferHandling } from "@/hooks/useOfferHandling";
 
 const SellerDashboard = () => {
@@ -18,6 +19,7 @@ const SellerDashboard = () => {
   const [showMainDashboard, setShowMainDashboard] = useState(false);
 
   const { requests, myOffers, loading, error, refetch } = useSellerData();
+  const { myParts, loading: partsLoading, error: partsError, refetch: refetchParts } = useMyPartsData();
   const { handleMakeOffer, handleWhatsAppContact, isSubmittingOffer } =
     useOfferHandling(refetch);
 
@@ -42,9 +44,10 @@ const SellerDashboard = () => {
   const handleRetry = () => {
     console.log("SellerDashboard: Retrying data fetch");
     refetch();
+    refetchParts();
   };
 
-  if (loading) {
+  if (loading || partsLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-orange-50 to-white dark:from-orange-900/20 dark:to-gray-900 flex items-center justify-center">
         <div className="text-center">
@@ -65,7 +68,7 @@ const SellerDashboard = () => {
           <h2 className="text-xl font-semibold text-foreground mb-2">
             Dashboard Error
           </h2>
-          <p className="text-muted-foreground mb-6">{error}</p>
+          <p className="text-muted-foreground mb-6">{error || partsError}</p>
           <Button
             onClick={handleRetry}
             className="bg-orange-600 hover:bg-orange-700"
@@ -100,6 +103,7 @@ const SellerDashboard = () => {
               onTabChange={setActiveTab}
               requests={requests}
               offers={myOffers}
+              myParts={myParts}
               onOfferSubmit={handleMakeOffer}
               onWhatsAppContact={handleWhatsAppContact}
               onChatContact={handleChatContact}


### PR DESCRIPTION
The seller dashboard was not displaying all the parts listed by the seller. This was because the dashboard was not fetching the seller's parts.

This commit fixes the issue by:
- Creating a new `useMyParts` hook to fetch the parts for the logged-in seller.
- Updating the `usePartManagement` hook to use the new `useMyParts` hook.
- Creating a new `useMyPartsData` hook to provide the seller's parts to the dashboard.
- Updating the `SellerDashboard` to use the new hook and pass the parts to the `SellerTabs` component.
- Updating the `SellerTabs` and `MyPartsTab` components to correctly display the parts.