### PR TITLE
feat: Apply dark mode to logos

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -13,14 +13,17 @@ const Logo: React.FC<LogoProps> = ({ className, isHero }) => {
     'w-auto object-contain',
     {
       'h-48 sm:h-56 md:h-64 lg:h-72': isHero,
-      'dark:invert': theme === 'dark',
     },
     className
   );
 
+  const logoSrc = theme === 'dark'
+    ? "/lovable-uploads/partmatch-hero-logo.png"
+    : "/lovable-uploads/0bb9488b-2f77-4f4c-b8b3-8aa9343b1d18.png";
+
   return (
     <img
-      src="/lovable-uploads/0bb9488b-2f77-4f4c-b8b3-8aa9343b1d18.png"
+      src={logoSrc}
       alt="PartMatch - Car Parts Marketplace"
       className={logoClasses}
     />


### PR DESCRIPTION
This commit applies the dark mode style to all the logos on all the pages and the hero section of the home page.

Instead of using a CSS filter, this commit introduces a new dark mode logo and conditionally renders it based on the current theme.