### PR TITLE
fix: Allow deleting listings with saved parts

### DIFF
--- a/supabase/migrations/20250725132500-fix-delete-listing-issue.sql
+++ b/supabase/migrations/20250725132500-fix-delete-listing-issue.sql
@@ -1,0 +1,7 @@
+-- Alter the foreign key constraint on saved_parts to use ON DELETE SET NULL
+ALTER TABLE public.saved_parts
+DROP CONSTRAINT saved_parts_part_id_fkey,
+ADD CONSTRAINT saved_parts_part_id_fkey
+  FOREIGN KEY (part_id)
+  REFERENCES public.car_parts(id)
+  ON DELETE SET NULL;


### PR DESCRIPTION
When you tried to delete a listing that another user had saved, the delete would fail due to a foreign key constraint violation. This was because the `saved_parts` table had an `ON DELETE CASCADE` constraint, and you did not have permission to delete the other user's saved part.

This change fixes the issue by changing the foreign key constraint to `ON DELETE SET NULL`. This will set the `part_id` to `NULL` in the `saved_parts` table when a listing is deleted, instead of trying to delete the `saved_parts` entry.