### PR TITLE
fix: ainsure consistent part counts across the app

### DIFF
--- a/src/hooks/useMyParts.ts
+++ b/src/hooks/useMyParts.ts
@@ -55,6 +55,7 @@ export const useMyParts = () => {
         `
         )
         .eq("supplier_id", user.id)
+        .in("status", ["available", "pending"])
         .order("created_at", { ascending: false });
 
       console.log("=== useMyParts Debug ===");

--- a/src/hooks/useMyPartsCount.ts
+++ b/src/hooks/useMyPartsCount.ts
@@ -13,7 +13,8 @@ export const useMyPartsCount = () => {
       const { count, error } = await supabase
         .from('car_parts')
         .select('*', { count: 'exact', head: true })
-        .eq('supplier_id', user.id);
+        .eq('supplier_id', user.id)
+        .in('status', ['available', 'pending']);
 
       if (error) throw error;
       setPartsCount(count || 0);


### PR DESCRIPTION
This commit fixes an inconsistency issue where the number of parts displayed to you was different in various parts of the UI. The root cause was that the queries fetching the parts list and the parts count were not filtering by the part's status. This resulted in all parts, including 'sold' and 'hidden' ones, being counted and fetched.

To resolve this, I've updated the following hooks:

- `useMyParts.ts`: The query now only fetches parts with the status of 'available' or 'pending'.
- `useMyPartsCount.ts`: The query now only counts parts with the status of 'available' or 'pending'.

These changes ensure that the parts list and the parts count are always consistent and reflect only the active listings.